### PR TITLE
Set block=False for plt.show() in plot_conv.py

### DIFF
--- a/emu/emu_plot/python/plot_conv.py
+++ b/emu/emu_plot/python/plot_conv.py
@@ -227,7 +227,7 @@ def plot_conv(frun):
         plt.xlim(tctrl_min, tctrl_max)
     
         plt.tight_layout()
-        plt.show()
+        plt.show(block=False)
     
         # Ask for new lag input
         ip = int(input(f'Enter lag to plot ... (0-{nlag-1} or -1 to exit)? ')) 


### PR DESCRIPTION
In the script plot_conv.py, set block=False in plt.show(). Otherwise, matplotlib will block the execution of the script, preventing it from continuing after displaying the plot.